### PR TITLE
Add sniff to check for `add_..._page()` functions + unit tests.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -3,6 +3,7 @@
 	<!-- For more information: https://make.wordpress.org/themes/handbook/review/ -->
 	<description>Standards any Theme to be published on wordpress.org should comply with.</description>
 
+	<rule ref="WordPress-Theme"/>
 
 	<!-- No PHP short open tags allowed. -->
 	<!-- Covers: https://github.com/Otto42/theme-check/blob/master/checks/phpshort.php -->

--- a/WordPress/Sniffs/Theme/NoAddAdminPagesSniff.php
+++ b/WordPress/Sniffs/Theme/NoAddAdminPagesSniff.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * WordPress_Sniffs_Theme_NoAddAdminPagesSniff.
+ *
+ * Forbids the use of add_..._page() functions within Themes with the exception of `add_theme_page()`.
+ *
+ * @category Theme
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_Theme_NoAddAdminPagesSniff extends WordPress_Sniffs_Functions_FunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict
+	 *
+	 * Example: groups => array(
+	 * 	'lambda' => array(
+	 * 		'type'      => 'error' | 'warning',
+	 * 		'message'   => 'Use anonymous functions instead please!',
+	 * 		'functions' => array( 'eval', 'create_function' ),
+	 * 	)
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'add_menu_pages' => array(
+				'type'      => 'error',
+				'message'   => 'Themes should use <strong>add_theme_page()</strong> for adding admin pages. Found %s.',
+				'functions' => array(
+					// Menu Pages.
+					'add_menu_page',
+					'add_object_page',
+					'add_utility_page',
+
+					// SubMenu Pages.
+					'add_submenu_page',
+
+					// WordPress Administration Menus.
+					'add_dashboard_page',
+					'add_posts_page',
+					'add_media_page',
+					'add_pages_page',
+					'add_comments_page',
+					'add_plugins_page',
+					'add_users_page',
+					'add_management_page',
+					'add_options_page',
+				),
+			),
+		);
+	} // end getGroups()
+
+} // end class

--- a/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.inc
+++ b/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.inc
@@ -1,0 +1,28 @@
+<?php
+
+// Menu Pages.
+add_menu_page();
+add_object_page();
+add_utility_page();
+
+// SubMenu Pages.
+add_submenu_page();
+
+// WordPress Administration Menus.
+add_dashboard_page();
+add_posts_page();
+add_media_page();
+add_pages_page();
+add_comments_page();
+add_plugins_page();
+add_users_page();
+add_management_page();
+add_options_page();
+
+// Add Theme Page is allowed.
+add_theme_page(); // Ok.
+
+// Method names within a Theme class should be fine.
+Theme_Object::add_menu_page(); // Ok.
+$this->add_plugins_page(); // Ok.
+$theme_object->add_options_page(); // Ok.

--- a/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.php
+++ b/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Unit test class for the NoAddAdminPages sniff.
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category Theme
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Tests_Theme_NoAddAdminPagesUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			4 => 1,
+			5 => 1,
+			6 => 1,
+			9 => 1,
+			12 => 1,
+			13 => 1,
+			14 => 1,
+			15 => 1,
+			16 => 1,
+			17 => 1,
+			18 => 1,
+			19 => 1,
+			20 => 1,
+		);
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
Closes #11.

[Edit] Changed over to use WordPress_Sniffs_Functions_FunctionRestrictionsSniff as the base class rather than Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
This allows for better error messages, keeping it more in line with what people have come to expect from Theme Check.