### PR TITLE
Add sniff for deprecated Theme related WP Constants.

### DIFF
--- a/WordPress/Sniffs/Theme/DeprecatedWPConstantsSniff.php
+++ b/WordPress/Sniffs/Theme/DeprecatedWPConstantsSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Forbids usage of deprecated WP CONSTANTS and recommends alternatives.
+ *
+ * @link     https://make.wordpress.org/themes/handbook/review/required/#core-functionality-and-features
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Sniffs_Theme_DeprecatedWPConstantsSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * List of deprecated WP constants and their replacements.
+	 *
+	 * @var array
+	 */
+	private $deprecated_constants = array(
+		'STYLESHEETPATH'      => 'get_stylesheet_directory()',
+		'TEMPLATEPATH'        => 'get_template_directory()',
+		'PLUGINDIR'           => 'WP_PLUGIN_DIR',
+		'MUPLUGINDIR'         => 'WPMU_PLUGIN_DIR',
+		'HEADER_IMAGE'        => 'add_theme_support( \'custom-header\' )',
+		'NO_HEADER_TEXT'      => 'add_theme_support( \'custom-header\' )',
+		'HEADER_TEXTCOLOR'    => 'add_theme_support( \'custom-header\' )',
+		'HEADER_IMAGE_WIDTH'  => 'add_theme_support( \'custom-header\' )',
+		'HEADER_IMAGE_HEIGHT' => 'add_theme_support( \'custom-header\' )',
+		'BACKGROUND_COLOR'    => 'add_theme_support( \'custom-background\' )',
+		'BACKGROUND_IMAGE'    => 'add_theme_support( \'custom-background\' )',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		if ( ! isset( $this->deprecated_constants[ $tokens[ $stackPtr ]['content'] ] ) ) {
+			return;
+		}
+
+		$prev = $phpcsFile->findPrevious( T_WHITESPACE, ( $stackPtr - 1 ), null, true );
+
+		if ( T_DOUBLE_COLON === $tokens[ $prev ]['code'] ) {
+			// Class constant of the same name.
+			return;
+		}
+
+		if ( T_NS_SEPARATOR === $tokens[ $prev ]['code'] && T_STRING === $tokens[ ( $prev - 1 ) ]['code'] ) {
+			// Namespaced constant of the same name.
+			return;
+		}
+
+		// Ok, this is really one of the deprecated constants.
+		$error = 'Found usage of constant "%s". Use %s instead.';
+		$data  = array( $tokens[ $stackPtr ]['content'], $this->deprecated_constants[ $tokens[ $stackPtr ]['content'] ] );
+		$phpcsFile->addError( $error, $stackPtr, 'Found', $data );
+
+	} // end process()
+
+} // end class

--- a/WordPress/Tests/Theme/DeprecatedWPConstantsUnitTest.inc
+++ b/WordPress/Tests/Theme/DeprecatedWPConstantsUnitTest.inc
@@ -1,0 +1,23 @@
+<?php
+
+define( 'STYLESHEETPATH', 'something' ); // Ok - will throw an error about already defined constant anyway.
+
+if ( defined( 'STYLESHEETPATH' ) ) { // Ok.
+	// Do something unrelated.
+}
+
+echo \mynamespace\STYLESHEETPATH; // Ok, not WP constant.
+
+echo My_Class::STYLESHEETPATH; // Ok, not WP constant.
+
+echo STYLESHEETPATH; // Bad.
+$folder = basename( TEMPLATEPATH ); // Bad.
+$file = PLUGINDIR . '/js/myfile.js'; // Bad.
+echo MUPLUGINDIR; // Bad.
+echo HEADER_IMAGE; // Bad.
+echo NO_HEADER_TEXT; // Bad.
+echo HEADER_TEXTCOLOR; // Bad.
+echo HEADER_IMAGE_WIDTH; // Bad.
+echo HEADER_IMAGE_HEIGHT; // Bad.
+echo BACKGROUND_COLOR; // Bad.
+echo BACKGROUND_IMAGE; // Bad.

--- a/WordPress/Tests/Theme/DeprecatedWPConstantsUnitTest.php
+++ b/WordPress/Tests/Theme/DeprecatedWPConstantsUnitTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_Theme_DeprecatedWPConstants
+ *
+ * A sniff unit test checks a .inc file for expected violations of a single
+ * coding standard. Expected errors and warnings are stored in this class.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ */
+class WordPress_Tests_Theme_DeprecatedWPConstantsUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			9 => ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ? 0 : 1 ),
+			13 => 1,
+			14 => 1,
+			15 => 1,
+			16 => 1,
+			17 => 1,
+			18 => 1,
+			19 => 1,
+			20 => 1,
+			21 => 1,
+			22 => 1,
+			23 => 1,
+		);
+
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
Covers the sniff + unit test for issue #23.

This PR covers the currently known list as can be found in: https://github.com/Otto42/theme-check/pull/162/files