### PR TITLE
Add sniff to check that <title> tags are not used. 

### DIFF
--- a/WordPress/Sniffs/Theme/NoTitleTagSniff.php
+++ b/WordPress/Sniffs/Theme/NoTitleTagSniff.php
@@ -83,7 +83,7 @@ class WordPress_Sniffs_Theme_NoTitleTagSniff implements PHP_CodeSniffer_Sniff {
 
 		// Now let's do the check for the <title> tag.
 		if ( false !== strpos( $content, '<title' ) ) {
-			$phpcsFile->addWarning( 'The title tag is only allowed within svg elements.', $stackPtr, 'NotAllowed' );
+			$phpcsFile->addError( "The title tag must not be used. Use add_theme_support( 'title-tag' ) instead.", $stackPtr, 'TagFound' );
 		}
 
 	} // end process()

--- a/WordPress/Sniffs/Theme/NoTitleTagSniff.php
+++ b/WordPress/Sniffs/Theme/NoTitleTagSniff.php
@@ -66,8 +66,8 @@ class WordPress_Sniffs_Theme_NoTitleTagSniff implements PHP_CodeSniffer_Sniff {
 			}
 		}
 
-		// We're not in svg, so check if it there's a <svg> open tag on this line.
-		if ( false !== strpos( $content, '<svg' ) ) {
+		// We're not in svg, so check if it there's a <svg> open tag on this line.  PHP 5.2 create a seperate token for `<s` we need to check that the first two letters in the next token is vg.
+		if ( false !== strpos( $content, '<svg' ) || ( '<s' === trim( $content ) && 'vg' === substr( $tokens[ ( $stackPtr + 1 ) ]['content'], 0, 2 ) ) ) {
 			if ( false === strpos( $content, '</svg>' ) ) {
 				// Skip the next lines until the closing svg tag, but do check any content
 				// on this line before the svg tag.

--- a/WordPress/Sniffs/Theme/NoTitleTagSniff.php
+++ b/WordPress/Sniffs/Theme/NoTitleTagSniff.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Sniffs_Theme_NoTitleTagSniff.
+ *
+ * Forbids the use of the title tag, unless it is in within an svg tag.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    carolinan
+ */
+class WordPress_Sniffs_Theme_NoTitleTagSniff implements PHP_CodeSniffer_Sniff {
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_INLINE_HTML, // Finds inline html.
+			T_CONSTANT_ENCAPSED_STRING, // Finds the title tag in php.
+		 );
+	} // end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token in
+	 *                                        the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$content = $tokens[ $stackPtr ]['content'];
+
+		/**
+		 * The sniff is performed line by line.
+		 * This adds a warning if the title tag is used, -unless the title tag is on the same line as an svg element.
+		 */
+		if ( strpos( $content, '<title>' ) !== false && strpos( $content, '<svg') === false ) {
+			$phpcsFile->addWarning( "The title tag is only allowed within svg elements.", $stackPtr, 'NotAllowed' );
+		}
+	} // end process()
+
+} // end class

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Unit test for the title tag. 
+ * The title tag is not allowed, unless it is used in an svg element.
+ */
+
+echo '<title>';
+?>
+<title>
+
+<svg width="500" height="300" xmlns="http://www.w3.org/2000/svg">
+	<g>
+		<title>SVG Title Demo example</title>
+		<rect x="10" y="10" width="200" height="50" style="fill:none; stroke:blue; stroke-width:1px"/>
+	</g>
+</svg>

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
@@ -4,13 +4,34 @@
  * The title tag is not allowed, unless it is used in an svg element.
  */
 
-echo '<title>';
+echo '<title>'; // Bad.
 ?>
-<title>
+<title> <!-- Bad. -->
 
 <svg width="500" height="300" xmlns="http://www.w3.org/2000/svg">
+	<g>
+		<title>SVG Title Demo example</title> <!-- Ok. -->
+		<rect x="10" y="10" width="200" height="50" style="fill:none; stroke:blue; stroke-width:1px"/>
+	</g>
+</svg>
+
+
+Some content before the svg tag <title>my title</title> and some more content <svg width="500" height="300" xmlns="http://www.w3.org/2000/svg"> <!-- Bad. -->
 	<g>
 		<title>SVG Title Demo example</title>
 		<rect x="10" y="10" width="200" height="50" style="fill:none; stroke:blue; stroke-width:1px"/>
 	</g>
-</svg>
+</svg> Some content after the svg tag <title>my title</title> and some more content <!-- Bad. -->
+
+<title>my title</title> <svg width="500" height="300" >...</svg> <!-- Bad. -->
+
+<svg width="500" height="300" >...</svg> <title>my title</title> <!-- Bad. -->
+
+<title>my title</title> <svg width="500" height="300" >...</svg> <title>my title</title> <!-- Bad. -->
+
+<?php
+echo '
+	<title>my title</title>' .  /* Bad. */ . '
+	<svg width="500" height="300" >
+		...
+	</svg> <title>my title</title>'; // Bad.

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.inc
@@ -18,7 +18,7 @@ echo '<title>'; // Bad.
 
 Some content before the svg tag <title>my title</title> and some more content <svg width="500" height="300" xmlns="http://www.w3.org/2000/svg"> <!-- Bad. -->
 	<g>
-		<title>SVG Title Demo example</title>
+		<title>SVG Title Demo example</title> <!-- Ok. -->
 		<rect x="10" y="10" width="200" height="50" style="fill:none; stroke:blue; stroke-width:1px"/>
 	</g>
 </svg> Some content after the svg tag <title>my title</title> and some more content <!-- Bad. -->

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.php
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.php
@@ -32,7 +32,8 @@ class WordPress_Tests_Theme_NoTitleTagUnitTest extends AbstractSniffUnitTest {
 			24 => 1,
 			26 => 1,
 			28 => 1,
-			30 => 1,
+			// PHP 5.2 has an issue tokenizing `<s` so splits the string into two.
+			30 => version_compare( PHP_VERSION, '5.3.0', '>=' ) ? 1 : 2,
 			34 => 1,
 			37 => 1,
 		);

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.php
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.php
@@ -2,27 +2,23 @@
 /**
  * Unit test class for WordPress Coding Standard.
  *
- * @category PHP
- * @package  PHP_CodeSniffer
- * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
  */
 
 /**
  * Unit test class for the NoTitleTag sniff.
  *
- * @category  PHP
- * @package   PHP_CodeSniffer
- * @author    carolinan
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.xx.0
  */
 class WordPress_Tests_Theme_NoTitleTagUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of errors that should occur on that line.
-	 *
-	 * @return array(int => int)
+	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
 		return array(
@@ -38,19 +34,16 @@ class WordPress_Tests_Theme_NoTitleTagUnitTest extends AbstractSniffUnitTest {
 			37 => 1,
 		);
 
-	} // end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of warnings that should occur on that line.
-	 *
-	 * @return array(int => int)
+	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
 		return array();
 
-	} // end getWarningList()
+	}
 
-} // end class
+} // End class.

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.php
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the NoTitleTag sniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    carolinan
+ */
+class WordPress_Tests_Theme_NoTitleTagUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array(
+			7 => 1,
+			9 => 1,
+			13 => 0,  // Titles in svg are allowed.
+		);
+
+	} // end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class

--- a/WordPress/Tests/Theme/NoTitleTagUnitTest.php
+++ b/WordPress/Tests/Theme/NoTitleTagUnitTest.php
@@ -28,7 +28,13 @@ class WordPress_Tests_Theme_NoTitleTagUnitTest extends AbstractSniffUnitTest {
 		return array(
 			7 => 1,
 			9 => 1,
-			13 => 0,  // Titles in svg are allowed.
+			19 => 1,
+			24 => 1,
+			26 => 1,
+			28 => 1,
+			30 => 1,
+			34 => 1,
+			37 => 1,
 		);
 
 	} // end getErrorList()


### PR DESCRIPTION
This addresses https://github.com/WPTRT/WordPress-Coding-Standards/issues/25