### PR TITLE
No Org In URI

### DIFF
--- a/WordPress/Sniffs/Theme/NoOrgInUriSniff.php
+++ b/WordPress/Sniffs/Theme/NoOrgInUriSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Sniffs_Theme_WordPress_Sniffs_Theme_NoOrgInUriSniff.
+ *
+ * Error : Verify in style.css that the Theme URI does not point to wordpress.org
+ * (with predefined list of themes which are exempt and live under the
+ * wordpressdotorg user or have a check based on Author name.
+ * We allow .org user profiles as Author URI, so only check the Theme URI.
+ * We also allow WordPress.com links.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    khacoder
+ */
+class WordPress_Sniffs_Theme_NoOrgInUriSniff extends WordPress_AbstractThemeSniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'CSS',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_COMMENT,
+		);
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		global $sniff_helper;
+
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		$fileName = basename( $phpcsFile->getFileName() );
+
+		if ( 'style.css' === $fileName ) {
+			global $sniff_helper;
+
+			$fileName = basename( $phpcsFile->getFileName() );
+			
+			$theme_uri = $sniff_helper['theme_data']['uri'];
+			$theme_author = $sniff_helper['theme_data']['author'];
+
+			if ( 'style.css' === $fileName ) {
+				if ( '' !== $theme_uri && false !== strpos( $token['content'], 'Theme URI' ) ) {
+					if ( false !== strpos( strtolower( $theme_uri ), 'wordpress.org' ) && 'the wordpress team' !== strtolower( $theme_author )
+					|| false !== strpos( strtolower( $theme_uri ), 'w.org' ) && 'the wordpress team' !== strtolower( $theme_author ) ) {
+						$phpcsFile->addError( 'Using a WordPress.org Theme URI is reserved for official themes.' , $stackPtr, 'NoOrgInThemeUri' );
+					}
+				}
+			}
+		}
+	}//end process()
+}

--- a/WordPress/Tests/Theme/NoOrgUriUnitTest.inc
+++ b/WordPress/Tests/Theme/NoOrgUriUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+	/**
+	 * Error check file for NoOrgUri sniff.
+	 * Note that this test file will not work without an accompanying style.css file.
+	 * The WordPress_AbstractThemeSniff class is also required.
+	 * All checks are done from the style.css file so this file is included for continuity only.
+	 */
+
+	echo 'this is a test file, that is not really needed for this sniff';

--- a/WordPress/Tests/Theme/NoOrgUriUnitTest.php
+++ b/WordPress/Tests/Theme/NoOrgUriUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_Theme_NoOrgUriUnitTest
+ *
+ * Error : Verify in style.css that the Theme URI does not point to wordpress.org
+ * (with predefined list of themes which are exempt and live under the
+ * wordpressdotorg user or have a check based on Author name.
+ * We allow .org user profiles as Author URI, so only check the Theme URI.
+ * We also allow WordPress.com links.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   khacoder
+ */
+class WordPress_Tests_Theme_AccessibilityTagCheckUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
No Org In URI
Checks that WordPress.org is not part of Theme URI.
Requires WordPress_AbstractThemeSniff class
