### PR TITLE
Style Tags Check

### DIFF
--- a/WordPress/Sniffs/Theme/StyleTagsCheckSniff.php
+++ b/WordPress/Sniffs/Theme/StyleTagsCheckSniff.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Sniffs_Theme_StyleTagsCheckSniff.
+ *
+ * ERROR | Check that any Tags in the style.css file header comply with the current 
+ * guidelines (allowed tags, deprecated tags (=> WARNING) etc). 
+ * See Theme-Check plugin - /checks/style_tags.php for the list.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    khacoder
+ */
+class WordPress_Sniffs_Theme_StyleTagsCheckSniff extends WordPress_AbstractThemeSniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'CSS',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_COMMENT,
+		);
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		// get tags list from style.css.
+		global $sniff_helper;
+		$themetags = array();
+		$themetags = $sniff_helper['theme_data']['tags'];
+		if ( ! is_array( $themetags ) ) {
+			return;
+		}
+
+		$deprecated_tags = array( 'flexible-width','fixed-width','black','blue','brown','gray','green','orange','pink','purple','red','silver','tan','white','yellow','dark','light','fixed-layout','fluid-layout','responsive-layout','blavatar','photoblogging','seasonal' );
+		$allowed_tags = array( 'one-column','two-columns','three-columns','four-columns','left-sidebar','right-sidebar','grid-layout','flexible-header','accessibility-ready','buddypress','custom-background','custom-colors','custom-header','custom-menu','custom-logo','editor-style','featured-image-header','featured-images','footer-widgets','front-page-post-form','full-width-template','microformats','post-formats','rtl-language-support','sticky-post','theme-options','threaded-comments','translation-ready','blog','e-commerce','education','entertainment','food-and-drink','holiday','news','photography','portfolio' );
+
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		$fileName = basename( $phpcsFile->getFileName() );
+
+		if ( 'style.css' === $fileName ) {
+			if ( false !== strpos( $token['content'] , 'Tags' ) ) {
+				foreach ( $themetags as $tag ) {
+					if ( in_array( $tag, $deprecated_tags, true ) && '' !== $tag ) {
+						$phpcsFile->addWarning( $tag . ' is deprecated, please remove it.', $stackPtr, 'TagsAllowedCheck' );
+					} elseif ( ! in_array( $tag, $allowed_tags, true ) && ! in_array( $tag, $deprecated_tags, true ) && '' !== $tag ) {
+						$phpcsFile->addError( $tag . ' is not an approved tag and must be removed.', $stackPtr, 'TagsAllowedCheck' );
+					}
+				}
+				return count( $tokens ) + 1;
+			}
+		}
+	}//end process()
+}

--- a/WordPress/Tests/Theme/StyleTagsCheckUnitTest.inc
+++ b/WordPress/Tests/Theme/StyleTagsCheckUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+	/**
+	 * Error check file for StyleTagsCheck sniff.
+	 * Note that this test file will not work without an accompanying style.css file.
+	 * The WordPress_AbstractThemeSniff class is also required.
+	 * All checks are done from the style.css file so this file is included for continuity only.
+	 */
+
+	echo 'this is a test file, that is not really needed for this sniff';

--- a/WordPress/Tests/Theme/StyleTagsCheckUnitTest.php
+++ b/WordPress/Tests/Theme/StyleTagsCheckUnitTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Unit test class for WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Tests_Theme_StyleTagsCheckUnitTest
+ *
+ * WERROR | Check that any Tags in the style.css file header comply with the current 
+ * guidelines (allowed tags, deprecated tags (=> WARNING) etc). 
+ * See Theme-Check plugin - /checks/style_tags.php for the list.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   khacoder
+ */
+class WordPress_Tests_Theme_StyleTagsCheckUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array();
+
+	} // end getWarningList()
+
+} // end class


### PR DESCRIPTION
Issue #52
Check style.css for unapproved tags and deprecated tags.
Requires WordPress_AbstractThemeSniff
