### PR TITLE
Warning for using include or require

### DIFF
--- a/WordPress/Sniffs/Theme/FileIncludeSniff.php
+++ b/WordPress/Sniffs/Theme/FileIncludeSniff.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * WordPress_Sniffs_Theme_FileIncludeSniff.
+ *
+ * WARNING (manual check required) | Check if a theme uses include(_once) or
+ * require(_once) (where they should use get_template_part()). Current implementation
+ * excluded the functions.php file from this check. We may want to continue doing so.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    khacoder
+ */
+class WordPress_Sniffs_Theme_FileIncludeSniff extends WordPress_AbstractThemeSniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_REQUIRE,
+			T_REQUIRE_ONCE,
+			T_INCLUDE,
+			T_INCLUDE_ONCE,
+		);
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+	 * @param int                  $stackPtr  The position of the current token
+	 *                                        in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( PHP_CodeSniffer_File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		$fileName = basename( $phpcsFile->getFileName() );
+
+		$checks = array(
+			'include"',
+			'include_once',
+			'require',
+			'require_once',
+		);
+
+		if ( 'functions.php' !== $fileName ) {
+			foreach ( $checks as $check ) {
+				if ( false !== strpos( $token['content'], $check ) ) {
+					$phpcsFile->addWarning( 'The theme appears to use include or require. If these are being used to include separate sections of a template from independent files, then <strong>get_template_part()</strong> should be used instead.' , $stackPtr, 'FileIncludeCheck' );
+				}
+			}
+		}
+	}//end process()
+}

--- a/WordPress/Tests/Theme/FileIncludeUnitTest.inc
+++ b/WordPress/Tests/Theme/FileIncludeUnitTest.inc
@@ -1,9 +1,8 @@
 <?php
 
-/* ---- include or require ---- 
- * No bad or good here, just issue a warning for manual check.
- * */
-include('/file.ext');
-include_once('/file.ext');
-require('/file.ext');
-require_once('/file.ext');
+include('/file.ext'); // Warning.
+include_once('/file.ext'); // Warning.
+require('/file.ext'); // Warning.
+require_once('/file.ext'); // Warning.
+include dirname( __FILE__ ) . '/myfile.php'; // Warning.
+require_once $path_to_file; // Warning.

--- a/WordPress/Tests/Theme/FileIncludeUnitTest.inc
+++ b/WordPress/Tests/Theme/FileIncludeUnitTest.inc
@@ -1,0 +1,9 @@
+<?php
+
+/* ---- include or require ---- 
+ * No bad or good here, just issue a warning for manual check.
+ * */
+include('/file.ext');
+include_once('/file.ext');
+require('/file.ext');
+require_once('/file.ext');

--- a/WordPress/Tests/Theme/FileIncludeUnitTest.php
+++ b/WordPress/Tests/Theme/FileIncludeUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ */
+
+/**
+ * Unit test class for the FileInclude sniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @author   khacoder
+ */
+class WordPress_Tests_Theme_FileIncludeUnitTest extends AbstractSniffUnitTest
+{
+
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getErrorList() {
+		return array();
+	}//end getErrorList()
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array(int => int)
+	 */
+	public function getWarningList() {
+		return array(
+			6 => 1,
+			7 => 1,
+			8 => 1,
+			9 => 1,
+		);
+	}//end getWarningList()
+}//end class
+
+?>

--- a/WordPress/Tests/Theme/FileIncludeUnitTest.php
+++ b/WordPress/Tests/Theme/FileIncludeUnitTest.php
@@ -1,51 +1,43 @@
 <?php
 /**
- * WordPress Coding Standard.
+ * Unit test class for WordPress Coding Standard.
  *
- * @category PHP
- * @package  PHP_CodeSniffer
- * @link     https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
  */
 
 /**
- * Unit test class for the FileInclude sniff.
+ * Unit test class for the Theme_FileInclude sniff.
  *
- * @category PHP
- * @package  PHP_CodeSniffer
- * @author   khacoder
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.xx.0
  */
-class WordPress_Tests_Theme_FileIncludeUnitTest extends AbstractSniffUnitTest
-{
-
+class WordPress_Tests_Theme_FileIncludeUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of errors that should occur on that line.
-	 *
-	 * @return array(int => int)
+	 * @return array <int line number> => <int number of errors>
 	 */
 	public function getErrorList() {
 		return array();
-	}//end getErrorList()
+	}
 
 	/**
 	 * Returns the lines where warnings should occur.
 	 *
-	 * The key of the array should represent the line number and the value
-	 * should represent the number of warnings that should occur on that line.
-	 *
-	 * @return array(int => int)
+	 * @return array <int line number> => <int number of warnings>
 	 */
 	public function getWarningList() {
 		return array(
+			3 => 1,
+			4 => 1,
+			5 => 1,
 			6 => 1,
 			7 => 1,
 			8 => 1,
-			9 => 1,
 		);
-	}//end getWarningList()
-}//end class
+	}
 
-?>
+} // End class.


### PR DESCRIPTION
Issue #66
Check if include(_once) or require(_once) is used, and issue a warning to see if get_template_part() or locate_template() is more appropriate.