### PR TITLE
Add rule to prohibit the use of the backtick shell execution operator.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -47,4 +47,7 @@
 		<type>warning</type>
 	</rule>
 
+	<!-- Prohibit the use of the backtick operator. -->
+	<rule ref="Generic.PHP.BacktickOperator"/>
+
 </ruleset>


### PR DESCRIPTION
Execution of shell commands should be discouraged. A number of the other commands along the same lines are discouraged via function sniffs, however, the backtick operator was so far ignored.

As the TR branch has now merged the current WPCS version including the updated PHPCS 2.7 requirement, I can finally send this one in :sunglasses: 

See: https://github.com/squizlabs/PHP_CodeSniffer/pull/1073