### PR TITLE
Change error silencing rule from warning to error.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -32,7 +32,12 @@
 	<rule ref="WordPress.VIP.PluginMenuSlug"/>
 
 	<!-- Do not silence error notices. e.g. Error Control Operator @.. -->
-	<rule ref="Generic.PHP.NoSilencedErrors" />
+	<rule ref="Generic.PHP.NoSilencedErrors">
+		<properties>
+			<property name="error" value="true"/>
+		</properties>
+	</rule>
+
 
 
 	<!-- Validate and/or sanitize untrusted data before entering into the database. -->


### PR DESCRIPTION
See https://github.com/WPTRT/WordPress-Coding-Standards/issues/83#issuecomment-268009879

@emiluzelac Care to test with this branch ?

FYI: in this case the specific sniff referenced has a public property which determines whether the sniff should throw a warning or an error. The property defaults to `false` (=warning), so changing the property to `true` fixes this. This also changes the error code the sniff uses which is why - in this case - this is the more appropriate way to change the error type.