### PR TITLE
Mark add_post_type_support as plugin territory

### DIFF
--- a/WordPress/Sniffs/Theme/PluginTerritoryFunctionsSniff.php
+++ b/WordPress/Sniffs/Theme/PluginTerritoryFunctionsSniff.php
@@ -42,6 +42,7 @@ class WordPress_Sniffs_Theme_PluginTerritoryFunctionsSniff extends WordPress_Abs
 					'add_shortcode',
 					'register_taxonomy_for_object_type',
 					'flush_rewrite_rules',
+					'add_post_type_support',
 				),
 			),
 		);

--- a/WordPress/Tests/Theme/PluginTerritoryFunctionsUnitTest.inc
+++ b/WordPress/Tests/Theme/PluginTerritoryFunctionsUnitTest.inc
@@ -5,6 +5,7 @@ register_taxonomy( 'mytaxonomy', 'myposttype' );
 add_shortcode( 'myshortcode' , 'myshortcode_function' );
 register_taxonomy_for_object_type( 'category', 'page' );
 flush_rewrite_rules( false );
+add_post_type_support( 'page', 'excerpt' );
 
 xyz_add_shortcode(); // OK.
 My_Plugin_Class::add_shortcode(); // OK.

--- a/WordPress/Tests/Theme/PluginTerritoryFunctionsUnitTest.php
+++ b/WordPress/Tests/Theme/PluginTerritoryFunctionsUnitTest.php
@@ -27,6 +27,7 @@ class WordPress_Tests_Theme_PluginTerritoryFunctionsUnitTest extends AbstractSni
 			5 => 1,
 			6 => 1,
 			7 => 1,
+			8 => 1,
 		);
 
 	}


### PR DESCRIPTION
`add_post_type_support( 'page', 'excerpt' )` is plugin territory.