### PR TITLE
Check Theme Text domain

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -37,6 +37,13 @@
 	<!-- Prevent path disclosure when using add_theme_page(). -->
 	<rule ref="WordPress.VIP.PluginMenuSlug"/>
 
+	<!--
+		Use a single unique theme slug – as the theme slug appears in style.css.
+		Covers: https://make.wordpress.org/themes/handbook/review/required/#language
+		The text domains still need to be passed via the CLI or defined in the XML ruleset. See: https://github.com/WPTRT/WordPress-Coding-Standards/pull/111
+	-->
+	<rule ref="WordPress.WP.I18n"/>
+
 	<!-- Do not silence error notices. e.g. Error Control Operator @.. -->
 	<rule ref="Generic.PHP.NoSilencedErrors">
 		<properties>


### PR DESCRIPTION
fixes #35 

With https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/685 multiple text domains are supported and with https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/807 we can easily pass the text domains via the cli.

`phpcs -p . --standard=WordPress-Theme --runtime-set text_domain my-slug,default`

Or via a custom ruleset.
```xml
<rule ref="WordPress.WP.I18n">
   <properties>
     <property name="text_domain" value="my-slug,default"/>
   </properties>
</rule>
```

We can then add the list of allowed framework text domains to the the Theme Check plugin.