### PR TITLE
Mark MissingUnslash as Warning

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -52,6 +52,13 @@
 	<rule ref="WordPress.VIP.ValidatedSanitizedInput.InputNotSanitized">
 		<type>warning</type>
 	</rule>
+	</rule>
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.InputNotValidatedNotSanitized">
+		<type>warning</type>
+	</rule>
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash">
+		<type>warning</type>
+	</rule>
 
 	<!-- All untrusted data should be escaped before output. -->
 	<!--


### PR DESCRIPTION
I missed one error notice in https://github.com/WPTRT/WordPress-Coding-Standards/pull/89