### PR TITLE
Prohibit overwriting of WP global variables

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -75,4 +75,7 @@
 	<!-- Prohibit the use of the backtick operator. -->
 	<rule ref="Generic.PHP.BacktickOperator"/>
 
+	<!-- Prohibit overwriting of WordPress global variables. -->
+	<rule ref="WordPress.Variables.GlobalVariables"/>
+
 </ruleset>


### PR DESCRIPTION
To be merged once upstream has been merged back. Upstream PR https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/736 (already merged) contains a number of bug fixes which make this acceptable for use. Before that it was throwing too many false positives. See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/300

Oh and before anyone asks: the `$content_width` variable is already excepted from the upstream sniff.