### PR TITLE
Prohibit the use of the eval() language construct in themes.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -84,4 +84,11 @@
 	<!-- Prohibit overwriting of WordPress global variables. -->
 	<rule ref="WordPress.Variables.GlobalVariables"/>
 
+	<!-- Prohibit the use of the eval() PHP language construct. -->
+	<rule ref="Squiz.PHP.Eval"/>
+	<rule ref="Squiz.PHP.Eval.Discouraged">
+		<type>error</type>
+		<message>eval() is a security risk so not allowed.</message>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
The `eval()` check used to be done through a function restriction sniff, but eval is a language construct, not a function.
Upstream this has now been changed, so it makes sense to apply the same change here.

See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/812