### PR TITLE
Add `PrefixAllGlobals` sniff to the ruleset.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -118,4 +118,10 @@
 		<type>error</type>
 	</rule>
 
+	<!-- Verify that everything in the global namespace is prefixed. -->
+	<!-- Covers: https://make.wordpress.org/themes/handbook/review/required/#code - last bullet. -->
+	<!-- NOTE: this sniff needs a custom property to be set for it to be activated. -->
+	<!-- See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace-->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals" />
+
 </ruleset>


### PR DESCRIPTION
~~:warning: This PR should not be merged until WPCS has been merged back into the TRTCS as the sniff has only recently been added to WPCS.~~

Rebased after the merge of #145. Merging should now be fine.

Fixes #129