### PR TITLE
Add `CapitalPDangit` sniff to the ruleset and turn it into an error.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -124,4 +124,10 @@
 	<!-- See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace-->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals" />
 
+		<!-- Check for correct spelling of WordPress. -->
+	<!-- Covers: https://make.wordpress.org/themes/handbook/review/required/#naming - third bullet. -->
+	<rule ref="WordPress.WP.CapitalPDangit">
+		<type>error</type>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
~~:warning: This PR should not be merged until WPCS has been merged back into the TRTCS as the sniff has only recently been added to WPCS.~~

Rebased after the merge of #145. Merging should now be fine.

Fixes #88