### PR TITLE
Minor code clean-up.

### DIFF
--- a/WordPress/Tests/Theme/NoAutoGenerateUnitTest.php
+++ b/WordPress/Tests/Theme/NoAutoGenerateUnitTest.php
@@ -39,7 +39,7 @@ class WordPress_Tests_Theme_NoAutoGenerateUnitTest extends AbstractSniffUnitTest
 					39 => 2,
 					45 => 2,
 				);
-				break;
+
 			case 'NoAutoGenerateUnitTest.css':
 				return array(
 					3  => 1,
@@ -51,10 +51,9 @@ class WordPress_Tests_Theme_NoAutoGenerateUnitTest extends AbstractSniffUnitTest
 					14 => 1,
 					15 => 1,
 				);
-				break;
+
 			default:
 				return array();
-				break;
 		}
 	}
 


### PR DESCRIPTION
`break` is superfluous if the code above it already returns out of the function call.

----
N.B.: the build failure is unrelated to this PR and has already been solved upstream via https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/912. A backmerge would solve it for this fork too.