### PR TITLE
CS: Fix code style of the ruleset as per the new upstream guidelines.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -7,7 +7,7 @@
 
 	<!-- No PHP short open tags allowed. -->
 	<!-- Covers: https://github.com/Otto42/theme-check/blob/master/checks/phpshort.php -->
-	<rule ref="Generic.PHP.DisallowShortOpenTag" />
+	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
 
 	<!-- Alternative PHP open tags not allowed. -->
 	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
@@ -25,22 +25,22 @@
 	</rule>
 
 	<!-- No ByteOrderMark allowed - important to prevent issues with content being sent before headers. -->
-	<rule ref="Generic.Files.ByteOrderMark" />
+	<rule ref="Generic.Files.ByteOrderMark"/>
 
 	<!-- No removal of the admin bar allowed -->
 	<!-- Covers: https://github.com/wordpress/theme-check/blob/master/checks/adminbar.php -->
 	<rule ref="WordPress.VIP.AdminBarRemoval">
 		<properties>
-			<property name="remove_only" value="false" />
+			<property name="remove_only" value="false"/>
 		</properties>
 	</rule>
 
 	<!-- Check that the I18N functions are used correctly. -->
 	<!-- This sniff can also check the text domain, provided it's passed to PHPCS. -->
-	<rule ref="WordPress.WP.I18n" />
+	<rule ref="WordPress.WP.I18n"/>
 
 	<!-- No hard coding of scripts and styles. Everything should be enqueued. -->
-	<rule ref="WordPress.WP.EnqueuedResources" />
+	<rule ref="WordPress.WP.EnqueuedResources"/>
 
 	<!-- Prevent path disclosure when using add_theme_page(). -->
 	<rule ref="WordPress.VIP.PluginMenuSlug"/>
@@ -51,8 +51,6 @@
 			<property name="error" value="true"/>
 		</properties>
 	</rule>
-
-
 
 	<!-- Validate and/or sanitize untrusted data before entering into the database. -->
 	<!--


### PR DESCRIPTION
Actual validation of this won't happen until the next back-merge from upstream, but this should allow the build for the back-merge to pass ;-)

----
N.B.: the build failure is unrelated to this PR and has already been solved upstream via https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/912. A backmerge would solve it for this fork too.