### PR TITLE
PHPCS 2.9.0: Update sniffs to use the new `PHP_CodeSniffer_Tokens::$textStringTokens` token array.

### DIFF
--- a/WordPress/Sniffs/Theme/NoAutoGenerateSniff.php
+++ b/WordPress/Sniffs/Theme/NoAutoGenerateSniff.php
@@ -51,11 +51,8 @@ class NoAutoGenerateSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		$tokens   = Tokens::$stringTokens;
-		$tokens[] = T_INLINE_HTML;
-		$tokens[] = T_HEREDOC;
+		$tokens   = Tokens::$textStringTokens;
 		$tokens[] = T_STRING; // Functions named after or prefixed with the generator name.
-		$tokens[] = T_NOWDOC;
 		$tokens[] = T_COMMENT;
 		$tokens[] = T_DOC_COMMENT_STRING;
 		return $tokens;

--- a/WordPress/Sniffs/Theme/NoFaviconSniff.php
+++ b/WordPress/Sniffs/Theme/NoFaviconSniff.php
@@ -88,12 +88,7 @@ class NoFaviconSniff extends Sniff {
 
 		$this->favicon_regex = sprintf( self::REGEX_TEMPLATE, implode( '|', $regex_parts ) );
 
-		$tokens   = Tokens::$stringTokens;
-		$tokens[] = T_INLINE_HTML;
-		$tokens[] = T_HEREDOC;
-		$tokens[] = T_NOWDOC;
-
-		return $tokens;
+		return Tokens::$textStringTokens;
 	}
 
 	/**

--- a/WordPress/Sniffs/Theme/NoTitleTagSniff.php
+++ b/WordPress/Sniffs/Theme/NoTitleTagSniff.php
@@ -36,12 +36,7 @@ class NoTitleTagSniff extends Sniff {
 	 * @return array
 	 */
 	public function register() {
-		$tokens                  = Tokens::$stringTokens;
-		$tokens[ T_INLINE_HTML ] = T_INLINE_HTML;
-		$tokens[ T_HEREDOC ]     = T_HEREDOC;
-		$tokens[ T_NOWDOC ]      = T_NOWDOC;
-
-		return $tokens;
+		return Tokens::$textStringTokens;
 	}
 
 	/**


### PR DESCRIPTION
~~:warning: This PR should not be merged until WPCS has been merged back into the TRTCS as the WPCS minimum requirement of PHPCS 2.9.0 has only recently been changed in WPCS (as PHPCS 2.9.0 has only just been released).~~

Rebased after the merge of #145. Amended the original commit with a minor change for PHPCS 3.x compatibility. Merging should now be fine.

Fixes #128