### PR TITLE
Ruleset: treat all files as UTF-8

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -5,6 +5,9 @@
 
 	<autoload>./../WordPress/PHPCSAliases.php</autoload>
 
+	<!-- Treat all files as UTF-8. -->
+	<config name="encoding" value="utf-8"/>
+
 	<rule ref="WordPress.Theme"/>
 
 	<!-- No PHP short open tags allowed. -->


### PR DESCRIPTION
This is the default in PHPCS 3.x, but should be set for maximum portability and documentation of how files will be treated.