### PR TITLE
Prohibit PHP closing tag at end of PHP-only file

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -14,6 +14,13 @@
 	<!-- Alternative PHP open tags not allowed. -->
 	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
 
+	<!-- Files should omit the closing PHP tag at the end of a file. -->
+	<rule ref="PSR2.Files.ClosingTag"/>
+	<rule ref="PSR2.Files.ClosingTag.NotAllowed">
+		<type>warning</type>
+		<message>To help prevent PHP "headers already send" errors the PHP closing tag at the end of the file should be removed.</message>
+	</rule>
+
 	<!-- Mixed line endings are not allowed. -->
 	<!-- Covers: https://github.com/Otto42/theme-check/blob/master/checks/lineendings.php -->
 	<rule ref="Internal.LineEndings.Mixed">


### PR DESCRIPTION
Not having a PHP closing tag if it would be the last thing in a file is best practice which should be adhered to as this can prevent PHP "headers already send" errors.

While this is not explicitly mentioned in the handbook, this can be considered to fall under the "Required: No PHP notices" rule.
Ref: https://make.wordpress.org/themes/handbook/review/required/explanations-and-examples/#code