### PR TITLE
Warn on empty statements

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -29,6 +29,9 @@
 	<!-- No ByteOrderMark allowed - important to prevent issues with content being sent before headers. -->
 	<rule ref="Generic.Files.ByteOrderMark"/>
 
+	<!-- PHP tags without anything between them is just sloppy. -->
+	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+
 	<!-- No removal of the admin bar allowed -->
 	<!-- Covers: https://github.com/wordpress/theme-check/blob/master/checks/adminbar.php -->
 	<rule ref="WordPress.VIP.AdminBarRemoval">


### PR DESCRIPTION
Add a sniff to the ruleset which will warn on completely empty statements `<?php     ?>`. The sniff includes a fixer to remove these superfluous tags.