### PR TITLE
Detect usage of deprecated WP classes and function call parameters

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -110,8 +110,10 @@
 		<message>The "goto" language construct should not be used.</message>
 	</rule>
 
-	<!-- Check for deprecated WordPress functions. -->
+	<!-- Check for use of deprecated WordPress classes, functions and function parameters. -->
+	<rule ref="WordPress.WP.DeprecatedClasses"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+	<rule ref="WordPress.WP.DeprecatedParameters"/>
 
 	<!-- Check for deprecated WordPress constants. -->
 	<!--


### PR DESCRIPTION
Adds two new upstream WPCS sniffs to the ruleset.

These sniffs will throw a `warning` if the class/function parameter was deprecated in any of the last three minors and an `error` if the class/parameter was deprecated before that.

(Partially) Fixes #72