### PR TITLE
Update gitignore with thumbs and mac specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,12 @@
 vendor
 composer.lock
 phpunit.xml
+
+# Mac OS custom attribute store and thumbnails
+*.DS_Store
+._*
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db


### PR DESCRIPTION
The `.DS_Store` started popping up when I wanted to check out certain branches, so this will just ignore it if a person is working on a Mac computer. If you have any additional Windows-specific file types to exclude let me know in the comment.