### PR TITLE
Add upstream DB related sniffs

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -54,6 +54,17 @@
 		</properties>
 	</rule>
 
+	<!-- While most themes shouldn't query the database directly, if they do, it should be done correctly. -->
+	<!-- Don't use the PHP database functions and classes, use the WP abstraction layer instead. -->
+	<rule ref="WordPress.DB.RestrictedClasses"/>
+	<rule ref="WordPress.DB.RestrictedFunctions"/>
+
+	<!-- All SQL queries should be prepared as close to the time of querying the database as possible. -->
+	<rule ref="WordPress.WP.PreparedSQL"/>
+
+	<!-- Verify that placeholders in prepared queries are used correctly. -->
+	<rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
+
 	<!-- Validate and/or sanitize untrusted data before entering into the database. -->
 	<!--
 		Revert to changing the type at the sniff level instead of the error code level


### PR DESCRIPTION
Adds four new sniffs from WPCS to the ruleset:
* `DB.RestrictedClasses` and `DB.RestrictedFunctions` will throw `error`s when usage of the PHP native DB functions and classes is detected.
* `WP.PreparedSQL` tries to find SQL queries with placeholders and will throw an `error` when the query is not (late) prepared.
* `DB.PreparedSQLPlaceholders` verifies that placeholders are used correctly in prepared queries to prevent issues related to the security holes patched in WP 4.8.x.