### PR TITLE
Add sniff to advise about hook names.

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -131,7 +131,21 @@
 	<!-- Covers: https://make.wordpress.org/themes/handbook/review/required/#code - last bullet. -->
 	<!-- NOTE: this sniff needs a custom property to be set for it to be activated. -->
 	<!-- See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace-->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals" />
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
+
+	<!-- Principle of least surprise: Advise to use lowercase, underscore separate hook names. -->
+	<!--
+		Change the type at the sniff level instead of the error code level
+		once the PR has been merged and the miminmum PHPCS version has been increased.
+		https://github.com/squizlabs/PHP_CodeSniffer/pull/1247
+	-->
+	<rule ref="WordPress.NamingConventions.ValidHookName"/>
+	<rule ref="WordPress.NamingConventions.ValidHookName.NotLowercase">
+		<type>warning</type>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores">
+		<type>warning</type>
+	</rule>
 
 	<!-- Check for correct spelling of WordPress. -->
 	<!-- Covers: https://make.wordpress.org/themes/handbook/review/required/#naming - third bullet. -->


### PR DESCRIPTION
While - as far as I know - this is not a TRT requirement, according to the [WP Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions) hook names should be all lowercase with words separated by underscores.

Themes which do not follow this guideline violate the "_[Principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)_" which advocates predictability of common features in software design.
To make this more concrete: end-users, child-theme creators etc expect hook names to follow a certain naming convention and may be "surprised" or even disbelieve that unconventional hook names, such as `MyName\email@checker`,  would work.

The sniff added by this PR checks whether hook names added by themes comply with the WP naming convention.

As this is not a hard requirement, the notices are downgraded from `error` to `warning`.