### PR TITLE
NoAddAdminPages: add `add_links_page()` to the functions list

### DIFF
--- a/WordPress/Sniffs/Theme/NoAddAdminPagesSniff.php
+++ b/WordPress/Sniffs/Theme/NoAddAdminPagesSniff.php
@@ -52,6 +52,7 @@ class NoAddAdminPagesSniff extends AbstractFunctionRestrictionsSniff {
 					// WordPress Administration Menus.
 					'add_dashboard_page',
 					'add_posts_page',
+					'add_links_page',
 					'add_media_page',
 					'add_pages_page',
 					'add_comments_page',

--- a/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.inc
+++ b/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.inc
@@ -18,6 +18,7 @@ add_plugins_page();
 add_users_page();
 add_management_page();
 add_options_page();
+add_links_page();
 
 // Add Theme Page is allowed.
 add_theme_page(); // Ok.

--- a/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.php
+++ b/WordPress/Tests/Theme/NoAddAdminPagesUnitTest.php
@@ -39,6 +39,7 @@ class NoAddAdminPagesUnitTest extends AbstractSniffUnitTest {
 			18 => 1,
 			19 => 1,
 			20 => 1,
+			21 => 1,
 		);
 	}
 


### PR DESCRIPTION
Even though the _Links_ menu is now disabled for new installs, the functionality does still exist and the function to add submenus to it has not been deprecated, so should be included in this sniff.