### PR TITLE
Add sniffs to detect accessing session data

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -147,4 +147,8 @@
 		</properties>
 	</rule>
 
+	<!-- Themes should not use the PHP session functions nor access the $_SESSION variable. -->
+	<rule ref="WordPress.VIP.SessionFunctionsUsage"/>
+	<rule ref="WordPress.VIP.SessionVariableUsage"/>
+
 </ruleset>


### PR DESCRIPTION
Themes should never need to access session data. These two sniffs make sure that errors are thrown when the PHP session functions are used, as well as when the `$_SESSION` global is accessed.