### PR TITLE
Add check for whitespace before PHP open tag

### DIFF
--- a/WordPress-Theme/ruleset.xml
+++ b/WordPress-Theme/ruleset.xml
@@ -17,6 +17,17 @@
 	<!-- Alternative PHP open tags not allowed. -->
 	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
 
+	<!-- Files which start with a PHP open tag should have no whitespace preceding it. -->
+	<!-- Once PHPCS 3.x is the minimum, this block can be removed as errorcodes can then be included individually. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile"/>
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines"/>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
+		<message>To help prevent PHP "headers already send" errors, whitespace before the PHP open tag should be removed.</message>
+	</rule>
+
 	<!-- Files should omit the closing PHP tag at the end of a file. -->
 	<rule ref="PSR2.Files.ClosingTag"/>
 	<rule ref="PSR2.Files.ClosingTag.NotAllowed">


### PR DESCRIPTION
This adds an upstream sniff which can check for whitespace before a PHP open tag.
As the sniff does more than just that, all other error codes from the sniff are excluded.

The check takes inline HTML into account and will not throw an error if the PHP open tag is not the first non-whitespace token in the file.

Notes:
* Changed the error message to make it very clear why this check is here.
* The upstream sniff does not handle unicode whitespace well. This is being discussed in an issue I opened upstream and will probably/hopefully be fixed soon.

Fixes #148